### PR TITLE
401 error caused by asterix encoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: php
+php:
+- 5.6
+- 5.5
+- 5.4
+- 5.3
+install:
+- curl -sS https://getcomposer.org/installer | php
+- npm install
+- grunt composer:install
+script: grunt test

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,29 @@
+module.exports = function(grunt) {
+
+  require('load-grunt-tasks')(grunt);
+
+  grunt.initConfig({
+    phpunit: {
+      classes: {
+        dir: 'test/unit'
+      },
+      options: {
+        bin: 'vendor/bin/phpunit',
+        configuration:'test/unit/phpunit.xml',
+        colors: true,
+        stopOnError:true,
+        stopOnFailure:true,
+        failOnFailures:true
+      }
+    },
+    composer : {
+      options : {
+        usePhp: true,
+        composerLocation: './composer.phar'
+      }
+    }
+  });
+
+  grunt.registerTask('test', ['phpunit']);
+  grunt.registerTask('default', ['composer:install', 'phpunit']);
+};

--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ Usage:
     }
 ```
 
+## Build
+
+Install using composer.
+
+```
+    php composer.phar install
+```
+
+Run Tests using:
+
+```
+    ./vendor/bin/phpunit test
+```
+
+
 ## TODO
 
 * Tool consumer class

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "LTI1x-php",
+  "version": "0.1.1",
+  "description": "IMS LTI 1.x for PHP",
+  "main": "Gruntfile.js",
+  "devDependencies": {
+    "grunt": "0.4.5",
+    "grunt-cli": "0.1.13",
+    "grunt-composer": "0.4.4",
+    "grunt-phpunit": "0.3.6",
+    "load-grunt-tasks": "3.1.0"
+  },
+  "scripts": {
+    "test": "grunt test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/talis/LTI1x-php.git"
+  },
+  "author": "Ross Singer",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/talis/LTI1x-php/issues"
+  },
+  "homepage": "https://github.com/talis/LTI1x-php"
+}

--- a/src/LTI1/ToolProvider.php
+++ b/src/LTI1/ToolProvider.php
@@ -674,11 +674,7 @@ class ToolProvider {
         if (is_array($input)) {
             return array_map(array('\LTI1\ToolProvider', 'urlencode_rfc3986'), $input);
         } else if (is_scalar($input)) {
-            return str_replace(
-                '+',
-                ' ',
-                str_replace('%7E', '~', rawurlencode($input))
-            );
+            return str_replace('+',' ',str_replace('%252A', '*', str_replace('%7E', '~', rawurlencode($input))));
         } else {
             return '';
         }

--- a/test/unit/ToolProviderTest.php
+++ b/test/unit/ToolProviderTest.php
@@ -438,4 +438,21 @@ class ToolProviderTest extends TestBase
         $provider = new \LTI1\ToolProvider(uniqid(), uniqid(),array());
         $this->assertFalse($provider->getCourseName());
     }
+
+    public function testGenerateBaseStringDoesNotEncodeAsterix()
+    {
+        $expectedBaseUri =
+            'POST&http%3A%2F%2Fwww.test.com%2Flti%2Flaunch&' .
+            'custom_node_code_regex%3D%255E%2528%255BA-Z0-9%255D%252B%2529_.*%2524'; // Unecoded *
+
+        $params = array(
+            'custom_node_code_regex'=>'^([A-Z0-9]+)_.*$'
+        );
+
+        $provider = new \LTI1\ToolProvider(uniqid(), uniqid(), $params);
+
+        $baseString = $provider->generateBaseString('POST', 'http://www.test.com/lti/launch', $params);
+
+        $this->assertEquals($expectedBaseUri, $baseString);
+    }
 }

--- a/test/unit/phpunit.xml
+++ b/test/unit/phpunit.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<phpunit bootstrap="../../vendor/autoload.php">
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">../../src</directory>
+        </whitelist>
+    </filter>
+    <testsuites>
+        <testsuite name="LTI1z-php client unit tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+
+</phpunit>


### PR DESCRIPTION
This pull requests changes the generation of the base string by the ToolProvider class so that it does not url encode an '*' character.

In [RFC1738: Uniform Resource Locators](http://www.rfc-editor.org/rfc/rfc1738.txt) it states that:

> Usually a URL has the same interpretation when an octet is represented by a character and when it encoded. However, this is not true for reserved characters: encoding a character reserved for a particular scheme may change the semantics of a URL.

> Thus, only alphanumerics, the special characters "$-_.+!*'(),", and reserved characters used for their reserved purposes may be used unencoded within a URL.

> On the other hand, characters that are not required to be encoded (including alphanumerics) may be encoded within the scheme-specific part of a URL, as long as they are not being used for a reserved purpose.

The [HTML 4](http://www.w3.org/TR/html4/interact/forms.html#h-17.13.4.1) spec refers to RFC1738.

So it is OK to have an unencoded '*' in a url.


In practice - Blackboard is not url encoding '*' characters, but LTI1x-php is. This is resulting in a difference in the url used for oauth token generation. Because the token is different, login via LTI is receiving a 401 Authentication failure.